### PR TITLE
Added Neutral Resources Language Attribut 

### DIFF
--- a/Stateless/Properties/AssemblyInfo.cs
+++ b/Stateless/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Resources;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -29,3 +30,4 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Stateless.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010077d5f127d9877b3b813017ddefb168b265f8041ec908984bf36071156ff911a7a27b5243decac72586ecf45edfb93c50fdf063639e39edff2238a2b999caf0b2c9767a1517cb1df747b58853503e03e1fb12f1336c35aa97ad8a8bc2984b7cae9f49cad2eedebb8cf59b3bd5f24fd9f3a53bd1a2d8499f4fe0d938873b0101ca")]
 
+[assembly: NeutralResourcesLanguageAttribute("en")]


### PR DESCRIPTION
- To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly). Set this to English.