### PR TITLE
DotGraph now renders OnEntry and OnExit actions with descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 bin
 obj
 Stateless.userprefs
+*.user
+
+# Visual Studio 2015 cache/options directory
+.vs/

--- a/Stateless.Tests/DotGraphFixture.cs
+++ b/Stateless.Tests/DotGraphFixture.cs
@@ -11,6 +11,16 @@ namespace Stateless.Tests
             return true;
         }
 
+        void OnEntry()
+        {
+
+        }
+
+        void OnExit()
+        {
+
+        }
+
         [Test]
         public void SimpleTransition()
         {
@@ -61,6 +71,23 @@ namespace Stateless.Tests
         }
 
         [Test]
+        public void WhenDiscriminatedByAnonymousGuardWithDescription()
+        {
+            Func<bool> anonymousGuard = () => true;
+
+            var expected = "digraph {" + System.Environment.NewLine
+                         + " A -> B [label=\"X [description]\"];" + System.Environment.NewLine
+                         + "}";
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .PermitIf(Trigger.X, State.B, anonymousGuard, "description");
+
+            Assert.AreEqual(expected, sm.ToDotGraph());
+        }
+
+        [Test]
         public void WhenDiscriminatedByNamedDelegate()
         {
             var expected = "digraph {" + System.Environment.NewLine
@@ -71,6 +98,21 @@ namespace Stateless.Tests
 
             sm.Configure(State.A)
                 .PermitIf(Trigger.X, State.B, IsTrue);
+
+            Assert.AreEqual(expected, sm.ToDotGraph());
+        }
+
+        [Test]
+        public void WhenDiscriminatedByNamedDelegateWithDescription()
+        {
+            var expected = "digraph {" + System.Environment.NewLine
+                         + " A -> B [label=\"X [description]\"];" + System.Environment.NewLine
+                         + "}";
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .PermitIf(Trigger.X, State.B, IsTrue, "description");
 
             Assert.AreEqual(expected, sm.ToDotGraph());
         }
@@ -102,6 +144,70 @@ namespace Stateless.Tests
             var trigger = sm.SetTriggerParameters<int>(Trigger.X);
             sm.Configure(State.A)
                 .PermitDynamic(trigger, i => i == 1 ? State.B : State.C);
+
+            Assert.AreEqual(expected, sm.ToDotGraph());
+        }
+
+        [Test]
+        public void OnEntryWithAnonymousActionAndDescription()
+        {
+            var expected = "digraph {" + System.Environment.NewLine
+                         + "node [shape=box];" + System.Environment.NewLine
+                         + " A -> \"enteredA\" [label=\"On Entry\" style=dotted];" + System.Environment.NewLine
+                         + "}";
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .OnEntry(() => { }, "enteredA");
+
+            Assert.AreEqual(expected, sm.ToDotGraph());
+        }
+
+        [Test]
+        public void OnEntryWithNamedDelegateActionAndDescription()
+        {
+            var expected = "digraph {" + System.Environment.NewLine
+                         + "node [shape=box];" + System.Environment.NewLine
+                         + " A -> \"enteredA\" [label=\"On Entry\" style=dotted];" + System.Environment.NewLine
+                         + "}";
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .OnEntry(OnEntry, "enteredA");
+
+            Assert.AreEqual(expected, sm.ToDotGraph());
+        }
+
+        [Test]
+        public void OnExitWithAnonymousActionAndDescription()
+        {
+            var expected = "digraph {" + System.Environment.NewLine
+                         + "node [shape=box];" + System.Environment.NewLine
+                         + " A -> \"exitA\" [label=\"On Exit\" style=dotted];" + System.Environment.NewLine
+                         + "}";
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .OnExit(() => { }, "exitA");
+
+            Assert.AreEqual(expected, sm.ToDotGraph());
+        }
+
+        [Test]
+        public void OnExitWithNamedDelegateActionAndDescription()
+        {
+            var expected = "digraph {" + System.Environment.NewLine
+                         + "node [shape=box];" + System.Environment.NewLine
+                         + " A -> \"exitA\" [label=\"On Exit\" style=dotted];" + System.Environment.NewLine
+                         + "}";
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .OnExit(OnExit, "exitA");
 
             Assert.AreEqual(expected, sm.ToDotGraph());
         }

--- a/Stateless.Tests/StateRepresentationFixture.cs
+++ b/Stateless.Tests/StateRepresentationFixture.cs
@@ -16,7 +16,7 @@ namespace Stateless.Tests
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
-            stateRepresentation.AddEntryAction((t, a) => actualTransition = t);
+            stateRepresentation.AddEntryAction((t, a) => actualTransition = t, "entryActionDescription");
             stateRepresentation.Enter(transition);
             Assert.AreEqual(transition, actualTransition);
         }
@@ -28,7 +28,7 @@ namespace Stateless.Tests
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
-            stateRepresentation.AddEntryAction((t, a) => actualTransition = t);
+            stateRepresentation.AddEntryAction((t, a) => actualTransition = t, "entryActionDescription");
             stateRepresentation.Exit(transition);
             Assert.IsNull(actualTransition);
         }
@@ -40,7 +40,7 @@ namespace Stateless.Tests
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
-            stateRepresentation.AddExitAction(t => actualTransition = t);
+            stateRepresentation.AddExitAction(t => actualTransition = t, "entryActionDescription");
             stateRepresentation.Exit(transition);
             Assert.AreEqual(transition, actualTransition);
         }
@@ -52,7 +52,7 @@ namespace Stateless.Tests
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
-            stateRepresentation.AddExitAction(t => actualTransition = t);
+            stateRepresentation.AddExitAction(t => actualTransition = t, "exitActionDescription");
             stateRepresentation.Enter(transition);
             Assert.IsNull(actualTransition);
         }
@@ -125,7 +125,7 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             var executed = false;
-            sub.AddEntryAction((t, a) => executed = true);
+            sub.AddEntryAction((t, a) => executed = true, "entryActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(super.UnderlyingState, sub.UnderlyingState, Trigger.X);
             sub.Enter(transition);
             Assert.IsTrue(executed);
@@ -139,7 +139,7 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             var executed = false;
-            sub.AddExitAction(t => executed = true);
+            sub.AddExitAction(t => executed = true, "exitActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(sub.UnderlyingState, super.UnderlyingState, Trigger.X);
             sub.Exit(transition);
             Assert.IsTrue(executed);
@@ -153,7 +153,7 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             var executed = false;
-            super.AddEntryAction((t, a) => executed = true);
+            super.AddEntryAction((t, a) => executed = true, "entryActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(super.UnderlyingState, sub.UnderlyingState, Trigger.X);
             super.Enter(transition);
             Assert.IsFalse(executed);
@@ -167,7 +167,7 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             var executed = false;
-            super.AddExitAction(t => executed = true);
+            super.AddExitAction(t => executed = true, "exitActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(super.UnderlyingState, sub.UnderlyingState, Trigger.X);
             super.Exit(transition);
             Assert.IsFalse(executed);
@@ -181,7 +181,7 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             var executed = false;
-            super.AddEntryAction((t, a) => executed = true);
+            super.AddEntryAction((t, a) => executed = true, "entryActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(State.C, sub.UnderlyingState, Trigger.X);
             sub.Enter(transition);
             Assert.IsTrue(executed);
@@ -195,7 +195,7 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             var executed = false;
-            super.AddExitAction(t => executed = true);
+            super.AddExitAction(t => executed = true, "exitActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(sub.UnderlyingState, State.C, Trigger.X);
             sub.Exit(transition);
             Assert.IsTrue(executed);
@@ -207,8 +207,8 @@ namespace Stateless.Tests
             var actual = new List<int>();
 
             var rep = CreateRepresentation(State.B);
-            rep.AddEntryAction((t, a) => actual.Add(0));
-            rep.AddEntryAction((t, a) => actual.Add(1));
+            rep.AddEntryAction((t, a) => actual.Add(0), "entryActionDescription");
+            rep.AddEntryAction((t, a) => actual.Add(1), "entryActionDescription");
 
             rep.Enter(new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X));
 
@@ -223,8 +223,8 @@ namespace Stateless.Tests
             var actual = new List<int>();
 
             var rep = CreateRepresentation(State.B);
-            rep.AddExitAction(t => actual.Add(0));
-            rep.AddExitAction(t => actual.Add(1));
+            rep.AddExitAction(t => actual.Add(0), "entryActionDescription");
+            rep.AddExitAction(t => actual.Add(1), "entryActionDescription");
 
             rep.Exit(new StateMachine<State, Trigger>.Transition(State.B, State.C, Trigger.X));
 
@@ -267,8 +267,8 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             int order = 0, subOrder = 0, superOrder = 0;
-            super.AddEntryAction((t, a) => superOrder = order++);
-            sub.AddEntryAction((t, a) => subOrder = order++);
+            super.AddEntryAction((t, a) => superOrder = order++, "entryActionDescription");
+            sub.AddEntryAction((t, a) => subOrder = order++, "entryActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(State.C, sub.UnderlyingState, Trigger.X);
             sub.Enter(transition);
             Assert.Less(superOrder, subOrder);
@@ -282,8 +282,8 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out super, out sub);
 
             int order = 0, subOrder = 0, superOrder = 0;
-            super.AddExitAction(t => superOrder = order++);
-            sub.AddExitAction(t => subOrder = order++);
+            super.AddExitAction(t => superOrder = order++, "entryActionDescription");
+            sub.AddExitAction(t => subOrder = order++, "entryActionDescription");
             var transition = new StateMachine<State, Trigger>.Transition(sub.UnderlyingState, State.C, Trigger.X);
             sub.Exit(transition);
             Assert.Less(subOrder, superOrder);

--- a/Stateless.Tests/Stateless.Tests.csproj
+++ b/Stateless.Tests/Stateless.Tests.csproj
@@ -112,6 +112,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Stateless/DotGraph.cs
+++ b/Stateless/DotGraph.cs
@@ -35,17 +35,39 @@ namespace Stateless
 
                         string line = (behaviour.Guard.Method.DeclaringType.Namespace.Equals("Stateless")) ?
                             string.Format(" {0} -> {1} [label=\"{2}\"];", source, destination, behaviour.Trigger) :
-                            string.Format(" {0} -> {1} [label=\"{2} [{3}]\"];", source, destination, behaviour.Trigger, behaviour.Guard.Method.Name);
+                            string.Format(" {0} -> {1} [label=\"{2} [{3}]\"];", source, destination, behaviour.Trigger, behaviour.Description);
 
                         lines.Add(line);
                     }
                 }
             }
 
-            if (unknownDestinations.Any()) 
+            if (unknownDestinations.Any())
             {
-                string label = string.Format(" {{ node [label=\"?\"] {0} }};", string.Join (" ", unknownDestinations));
+                string label = string.Format(" {{ node [label=\"?\"] {0} }};", string.Join(" ", unknownDestinations));
                 lines.Insert(0, label);
+            }
+
+            if (_stateConfiguration.Any(s => s.Value.EntryActions.Any() || s.Value.ExitActions.Any()))
+            {
+                lines.Add("node [shape=box];");
+
+                foreach (var stateCfg in _stateConfiguration)
+                {
+                    TState source = stateCfg.Key;
+
+                    foreach (var entryAction in stateCfg.Value.EntryActions)
+                    {
+                        string line = string.Format(" {0} -> \"{1}\" [label=\"On Entry\" style=dotted];", source, entryAction.Description);
+                        lines.Add(line);
+                    }
+
+                    foreach (var exitAction in stateCfg.Value.ExitActions)
+                    {
+                        string line = string.Format(" {0} -> \"{1}\" [label=\"On Exit\" style=dotted];", source, exitAction.Description);
+                        lines.Add(line);
+                    }
+                }
             }
 
             return "digraph {" + System.Environment.NewLine +

--- a/Stateless/DotGraph.cs
+++ b/Stateless/DotGraph.cs
@@ -35,7 +35,7 @@ namespace Stateless
 
                         string line = (behaviour.Guard.Method.DeclaringType.Namespace.Equals("Stateless")) ?
                             string.Format(" {0} -> {1} [label=\"{2}\"];", source, destination, behaviour.Trigger) :
-                            string.Format(" {0} -> {1} [label=\"{2} [{3}]\"];", source, destination, behaviour.Trigger, behaviour.Description);
+                            string.Format(" {0} -> {1} [label=\"{2} [{3}]\"];", source, destination, behaviour.Trigger, behaviour.GuardDescription);
 
                         lines.Add(line);
                     }

--- a/Stateless/DotGraph.cs
+++ b/Stateless/DotGraph.cs
@@ -56,15 +56,15 @@ namespace Stateless
                 {
                     TState source = stateCfg.Key;
 
-                    foreach (var entryAction in stateCfg.Value.EntryActions)
+                    foreach (var entryActionBehaviour in stateCfg.Value.EntryActions)
                     {
-                        string line = string.Format(" {0} -> \"{1}\" [label=\"On Entry\" style=dotted];", source, entryAction.Description);
+                        string line = string.Format(" {0} -> \"{1}\" [label=\"On Entry\" style=dotted];", source, entryActionBehaviour.ActionDescription);
                         lines.Add(line);
                     }
 
-                    foreach (var exitAction in stateCfg.Value.ExitActions)
+                    foreach (var exitActionBehaviour in stateCfg.Value.ExitActions)
                     {
-                        string line = string.Format(" {0} -> \"{1}\" [label=\"On Exit\" style=dotted];", source, exitAction.Description);
+                        string line = string.Format(" {0} -> \"{1}\" [label=\"On Exit\" style=dotted];", source, exitActionBehaviour.ActionDescription);
                         lines.Add(line);
                     }
                 }

--- a/Stateless/DynamicTriggerBehaviour.cs
+++ b/Stateless/DynamicTriggerBehaviour.cs
@@ -11,8 +11,8 @@ namespace Stateless
         {
             readonly Func<object[], TState> _destination;
 
-            public DynamicTriggerBehaviour(TTrigger trigger, Func<object[], TState> destination, Func<bool> guard)
-                : base(trigger, guard)
+            public DynamicTriggerBehaviour(TTrigger trigger, Func<object[], TState> destination, Func<bool> guard, string description)
+                : base(trigger, guard, description)
             {
                 _destination = Enforce.ArgumentNotNull(destination, "destination");
             }

--- a/Stateless/EntryActionBehaviour.cs
+++ b/Stateless/EntryActionBehaviour.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        internal class EntryActionBehavior
+        {
+            readonly string _description;
+            readonly Action<Transition, object[]> _action;
+
+            public EntryActionBehavior(Action<Transition, object[]> action, string description)
+            {
+                _action = action;
+                _description = description;
+            }
+
+            internal string Description { get { return string.IsNullOrEmpty(_description) ? _action.Method.Name : _description; } }
+            internal Action<Transition, object[]> Action  { get { return _action; } }
+        }
+    }
+}

--- a/Stateless/EntryActionBehaviour.cs
+++ b/Stateless/EntryActionBehaviour.cs
@@ -9,16 +9,16 @@ namespace Stateless
     {
         internal class EntryActionBehavior
         {
-            readonly string _description;
+            readonly string _actionDescription;
             readonly Action<Transition, object[]> _action;
 
-            public EntryActionBehavior(Action<Transition, object[]> action, string description)
+            public EntryActionBehavior(Action<Transition, object[]> action, string actionDescription)
             {
                 _action = action;
-                _description = description;
+                _actionDescription = actionDescription;
             }
 
-            internal string Description { get { return string.IsNullOrEmpty(_description) ? _action.Method.Name : _description; } }
+            internal string ActionDescription { get { return string.IsNullOrEmpty(_actionDescription) ? _action.Method.Name : _actionDescription; } }
             internal Action<Transition, object[]> Action  { get { return _action; } }
         }
     }

--- a/Stateless/EntryActionBehaviour.cs
+++ b/Stateless/EntryActionBehaviour.cs
@@ -15,10 +15,10 @@ namespace Stateless
             public EntryActionBehavior(Action<Transition, object[]> action, string actionDescription)
             {
                 _action = action;
-                _actionDescription = actionDescription;
+                _actionDescription = Enforce.ArgumentNotNull(actionDescription, nameof(actionDescription));
             }
 
-            internal string ActionDescription { get { return string.IsNullOrEmpty(_actionDescription) ? _action.Method.Name : _actionDescription; } }
+            internal string ActionDescription { get { return _actionDescription; } }
             internal Action<Transition, object[]> Action  { get { return _action; } }
         }
     }

--- a/Stateless/ExitActionBehaviour.cs
+++ b/Stateless/ExitActionBehaviour.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        internal class ExitActionBehavior
+        {
+            readonly string _description;
+            readonly Action<Transition> _action;
+
+            public ExitActionBehavior(Action<Transition> action, string description)
+            {
+                _action = action;
+                _description = description;
+            }
+
+            internal string Description { get { return string.IsNullOrEmpty(_description) ? _action.Method.Name : _description; } }
+            internal Action<Transition> Action { get { return _action; } }
+        }
+    }
+}

--- a/Stateless/ExitActionBehaviour.cs
+++ b/Stateless/ExitActionBehaviour.cs
@@ -9,16 +9,16 @@ namespace Stateless
     {
         internal class ExitActionBehavior
         {
-            readonly string _description;
+            readonly string _actionDescription;
             readonly Action<Transition> _action;
 
-            public ExitActionBehavior(Action<Transition> action, string description)
+            public ExitActionBehavior(Action<Transition> action, string actionDescription)
             {
                 _action = action;
-                _description = description;
+                _actionDescription = actionDescription;
             }
 
-            internal string Description { get { return string.IsNullOrEmpty(_description) ? _action.Method.Name : _description; } }
+            internal string ActionDescription { get { return string.IsNullOrEmpty(_actionDescription) ? _action.Method.Name : _actionDescription; } }
             internal Action<Transition> Action { get { return _action; } }
         }
     }

--- a/Stateless/ExitActionBehaviour.cs
+++ b/Stateless/ExitActionBehaviour.cs
@@ -15,10 +15,10 @@ namespace Stateless
             public ExitActionBehavior(Action<Transition> action, string actionDescription)
             {
                 _action = action;
-                _actionDescription = actionDescription;
+                _actionDescription = Enforce.ArgumentNotNull(actionDescription, nameof(actionDescription));
             }
 
-            internal string ActionDescription { get { return string.IsNullOrEmpty(_actionDescription) ? _action.Method.Name : _actionDescription; } }
+            internal string ActionDescription { get { return _actionDescription; } }
             internal Action<Transition> Action { get { return _action; } }
         }
     }

--- a/Stateless/IgnoredTriggerBehaviour.cs
+++ b/Stateless/IgnoredTriggerBehaviour.cs
@@ -10,7 +10,12 @@ namespace Stateless
         internal class IgnoredTriggerBehaviour : TriggerBehaviour
         {
             public IgnoredTriggerBehaviour(TTrigger trigger, Func<bool> guard)
-                : base(trigger, guard)
+                : this(trigger, guard, string.Empty)
+            {
+            }
+
+            public IgnoredTriggerBehaviour(TTrigger trigger, Func<bool> guard, string description)
+                : base(trigger, guard, description)
             {
             }
 

--- a/Stateless/StateConfiguration.cs
+++ b/Stateless/StateConfiguration.cs
@@ -426,10 +426,14 @@ namespace Stateless
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
-            public StateConfiguration PermitDynamicIf(TTrigger trigger, Func<TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
+            public StateConfiguration PermitDynamicIf(TTrigger trigger, Func<TState> destinationStateSelector, Func<bool> guard, string guardDescription = null)
             {
                 Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
-                return InternalPermitDynamicIf(trigger, args => destinationStateSelector(), guard, guardDescription);
+                return InternalPermitDynamicIf(
+                    trigger, 
+                    args => destinationStateSelector(), 
+                    guard,
+                    guardDescription != null ? guardDescription : guard?.Method.Name);
             }
 
             /// <summary>
@@ -444,7 +448,7 @@ namespace Stateless
             /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
+            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<bool> guard, string guardDescription = null)
             {
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
                 Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
@@ -453,7 +457,7 @@ namespace Stateless
                     args => destinationStateSelector(
                         ParameterConversion.Unpack<TArg0>(args, 0)),
                     guard,
-                    guardDescription);
+                    guardDescription != null ? guardDescription : guard?.Method.Name);
             }
 
             /// <summary>
@@ -469,7 +473,7 @@ namespace Stateless
             /// <returns>The reciever.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<bool> guard, string guardDescription = null)
             {
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
                 Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
@@ -479,7 +483,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1)),
                     guard,
-                    guardDescription);
+                    guardDescription != null ? guardDescription : guard?.Method.Name);
             }
 
             /// <summary>
@@ -496,7 +500,7 @@ namespace Stateless
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<bool> guard, string guardDescription = null)
             {
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
                 Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
@@ -507,7 +511,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg1>(args, 1),
                         ParameterConversion.Unpack<TArg2>(args, 2)),
                     guard,
-                    guardDescription);
+                    guardDescription != null ? guardDescription : guard?.Method.Name);
             }
 
             void EnforceNotIdentityTransition(TState destination)

--- a/Stateless/StateConfiguration.cs
+++ b/Stateless/StateConfiguration.cs
@@ -32,7 +32,7 @@ namespace Stateless
             public StateConfiguration Permit(TTrigger trigger, TState destinationState)
             {
                 EnforceNotIdentityTransition(destinationState);
-                return InternalPermit(trigger, destinationState);
+                return InternalPermit(trigger, destinationState, string.Empty);
             }
 
             /// <summary>
@@ -43,11 +43,12 @@ namespace Stateless
             /// transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
+            /// <param name="description">Guard description</param>
             /// <returns>The reciever.</returns>
-            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, Func<bool> guard)
+            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string description = "")
             {
                 EnforceNotIdentityTransition(destinationState);
-                return InternalPermitIf(trigger, destinationState, guard);
+                return InternalPermitIf(trigger, destinationState, guard, description);
             }
 
             /// <summary>
@@ -62,7 +63,7 @@ namespace Stateless
             /// </remarks>
             public StateConfiguration PermitReentry(TTrigger trigger)
             {
-                return InternalPermit(trigger, _representation.UnderlyingState);
+                return InternalPermit(trigger, _representation.UnderlyingState, string.Empty);
             }
 
             /// <summary>
@@ -72,14 +73,15 @@ namespace Stateless
             /// <param name="trigger">The accepted trigger.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
+            /// <param name="description">Guard description</param>
             /// <returns>The reciever.</returns>
             /// <remarks>
             /// Applies to the current state only. Will not re-execute superstate actions, or
             /// cause actions to execute transitioning between super- and sub-states.
             /// </remarks>
-            public StateConfiguration PermitReentryIf(TTrigger trigger, Func<bool> guard)
+            public StateConfiguration PermitReentryIf(TTrigger trigger, Func<bool> guard, string description = "")
             {
-                return InternalPermitIf(trigger, _representation.UnderlyingState, guard);
+                return InternalPermitIf(trigger, _representation.UnderlyingState, guard, description);
             }
             /// <summary>
             /// Ignore the specified trigger when in the configured state.
@@ -96,13 +98,14 @@ namespace Stateless
             /// returns true..
             /// </summary>
             /// <param name="trigger">The trigger to ignore.</param>
+            /// <param name="description">Guard description</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be ignored.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration IgnoreIf(TTrigger trigger, Func<bool> guard)
+            public StateConfiguration IgnoreIf(TTrigger trigger, Func<bool> guard, string description = "")
             {
                 Enforce.ArgumentNotNull(guard, "guard");
-                _representation.AddTriggerBehaviour(new IgnoredTriggerBehaviour(trigger, guard));
+                _representation.AddTriggerBehaviour(new IgnoredTriggerBehaviour(trigger, guard, description));
                 return this;
             }
 
@@ -111,11 +114,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="entryAction">Action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntry(Action entryAction)
+            public StateConfiguration OnEntry(Action entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntry(t => entryAction());
+                return OnEntry(t => entryAction(), description);
             }
 
             /// <summary>
@@ -123,11 +127,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntry(Action<Transition> entryAction)
+            public StateConfiguration OnEntry(Action<Transition> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                _representation.AddEntryAction((t, args) => entryAction(t));
+                _representation.AddEntryAction((t, args) => entryAction(t), description);
                 return this;
             }
             /// <summary>
@@ -136,11 +141,12 @@ namespace Stateless
             /// </summary>
             /// <param name="entryAction">Action to execute.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom(TTrigger trigger, Action entryAction)
+            public StateConfiguration OnEntryFrom(TTrigger trigger, Action entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom(trigger, t => entryAction());
+                return OnEntryFrom(trigger, t => entryAction(), description);
             }
 
             /// <summary>
@@ -149,11 +155,12 @@ namespace Stateless
             /// </summary>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom(TTrigger trigger, Action<Transition> entryAction)
+            public StateConfiguration OnEntryFrom(TTrigger trigger, Action<Transition> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                _representation.AddEntryAction(trigger, (t, args) => entryAction(t));
+                _representation.AddEntryAction(trigger, (t, args) => entryAction(t), description);
                 return this;
             }
 
@@ -164,11 +171,12 @@ namespace Stateless
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0> entryAction)
+            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0>(trigger, (a0, t) => entryAction(a0));
+                return OnEntryFrom<TArg0>(trigger, (a0, t) => entryAction(a0), description);
             }
 
             /// <summary>
@@ -178,13 +186,14 @@ namespace Stateless
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0, Transition> entryAction)
+            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0, Transition> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
-                    ParameterConversion.Unpack<TArg0>(args, 0), t));
+                    ParameterConversion.Unpack<TArg0>(args, 0), t), description);
                 return this;
             }
 
@@ -196,11 +205,12 @@ namespace Stateless
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1> entryAction)
+            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0, TArg1>(trigger, (a0, a1, t) => entryAction(a0, a1));
+                return OnEntryFrom<TArg0, TArg1>(trigger, (a0, a1, t) => entryAction(a0, a1), description);
             }
 
             /// <summary>
@@ -211,14 +221,15 @@ namespace Stateless
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1, Transition> entryAction)
+            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1, Transition> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
-                    ParameterConversion.Unpack<TArg1>(args, 1), t));
+                    ParameterConversion.Unpack<TArg1>(args, 1), t), description);
                 return this;
             }
 
@@ -231,11 +242,12 @@ namespace Stateless
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2> entryAction)
+            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0, TArg1, TArg2>(trigger, (a0, a1, a2, t) => entryAction(a0, a1, a2));
+                return OnEntryFrom<TArg0, TArg1, TArg2>(trigger, (a0, a1, a2, t) => entryAction(a0, a1, a2), description);
             }
 
             /// <summary>
@@ -247,15 +259,16 @@ namespace Stateless
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2, Transition> entryAction)
+            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2, Transition> entryAction, string description = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
-                    ParameterConversion.Unpack<TArg2>(args, 2), t));
+                    ParameterConversion.Unpack<TArg2>(args, 2), t), description);
                 return this;
             }
 
@@ -264,11 +277,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="exitAction">Action to execute.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnExit(Action exitAction)
+            public StateConfiguration OnExit(Action exitAction, string description = "")
             {
                 Enforce.ArgumentNotNull(exitAction, "exitAction");
-                return OnExit(t => exitAction());
+                return OnExit(t => exitAction(), description);
             }
 
             /// <summary>
@@ -276,11 +290,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="exitAction">Action to execute, providing details of the transition.</param>
+            /// <param name="description">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnExit(Action<Transition> exitAction)
+            public StateConfiguration OnExit(Action<Transition> exitAction, string description = "")
             {
                 Enforce.ArgumentNotNull(exitAction, "exitAction");
-                _representation.AddExitAction(exitAction);
+                _representation.AddExitAction(exitAction, description);
                 return this;
             }
 
@@ -372,11 +387,12 @@ namespace Stateless
             /// that the trigger will cause a transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
+            /// <param name="description">Guard description</param>
             /// <returns>The reciever.</returns>
-            public StateConfiguration PermitDynamicIf(TTrigger trigger, Func<TState> destinationStateSelector, Func<bool> guard)
+            public StateConfiguration PermitDynamicIf(TTrigger trigger, Func<TState> destinationStateSelector, Func<bool> guard, string description = "")
             {
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
-                return InternalPermitDynamicIf(trigger, args => destinationStateSelector(), guard);
+                return InternalPermitDynamicIf(trigger, args => destinationStateSelector(), guard, description);
             }
 
             /// <summary>
@@ -388,9 +404,10 @@ namespace Stateless
             /// that the trigger will cause a transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
+            /// <param name="description">Guard description</param>
             /// <returns>The reciever.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<bool> guard)
+            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<bool> guard, string description = "")
             {
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
@@ -398,7 +415,8 @@ namespace Stateless
                     trigger.Trigger,
                     args => destinationStateSelector(
                         ParameterConversion.Unpack<TArg0>(args, 0)),
-                    guard);
+                    guard,
+                    description);
             }
 
             /// <summary>
@@ -410,10 +428,11 @@ namespace Stateless
             /// that the trigger will cause a transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
+            /// <param name="description">Guard description</param>
             /// <returns>The reciever.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<bool> guard)
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<bool> guard, string description = "")
             {
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
@@ -422,7 +441,8 @@ namespace Stateless
                     args => destinationStateSelector(
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1)),
-                    guard);
+                    guard,
+                    description);
             }
 
             /// <summary>
@@ -435,10 +455,11 @@ namespace Stateless
             /// <returns>The reciever.</returns>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
+            /// <param name="description">Guard description</param>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<bool> guard)
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<bool> guard, string description = "")
             {
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
@@ -448,7 +469,8 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1),
                         ParameterConversion.Unpack<TArg2>(args, 2)),
-                    guard);
+                    guard,
+                    description);
             }
 
             void EnforceNotIdentityTransition(TState destination)
@@ -459,28 +481,28 @@ namespace Stateless
                 }
             }
 
-            StateConfiguration InternalPermit(TTrigger trigger, TState destinationState)
+            StateConfiguration InternalPermit(TTrigger trigger, TState destinationState, string description)
             {
-                return InternalPermitIf(trigger, destinationState, () => true);
+                return InternalPermitIf(trigger, destinationState, () => true, description);
             }
 
-            StateConfiguration InternalPermitIf(TTrigger trigger, TState destinationState, Func<bool> guard)
+            StateConfiguration InternalPermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string description)
             {
                 Enforce.ArgumentNotNull(guard, "guard");
-                _representation.AddTriggerBehaviour(new TransitioningTriggerBehaviour(trigger, destinationState, guard));
+                _representation.AddTriggerBehaviour(new TransitioningTriggerBehaviour(trigger, destinationState, guard, description));
                 return this;                
             }
 
-            StateConfiguration InternalPermitDynamic(TTrigger trigger, Func<object[], TState> destinationStateSelector)
+            StateConfiguration InternalPermitDynamic(TTrigger trigger, Func<object[], TState> destinationStateSelector, string description)
             {
-                return InternalPermitDynamicIf(trigger, destinationStateSelector, NoGuard);
+                return InternalPermitDynamicIf(trigger, destinationStateSelector, NoGuard, description);
             }
 
-            StateConfiguration InternalPermitDynamicIf(TTrigger trigger, Func<object[], TState> destinationStateSelector, Func<bool> guard)
+            StateConfiguration InternalPermitDynamicIf(TTrigger trigger, Func<object[], TState> destinationStateSelector, Func<bool> guard, string description)
             {
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
                 Enforce.ArgumentNotNull(guard, "guard");
-                _representation.AddTriggerBehaviour(new DynamicTriggerBehaviour(trigger, destinationStateSelector, guard));
+                _representation.AddTriggerBehaviour(new DynamicTriggerBehaviour(trigger, destinationStateSelector, guard, description));
                 return this;
             }
         }

--- a/Stateless/StateConfiguration.cs
+++ b/Stateless/StateConfiguration.cs
@@ -43,12 +43,12 @@ namespace Stateless
             /// transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
-            /// <param name="description">Guard description</param>
+            /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
-            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string description = "")
+            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string guardDescription = "")
             {
                 EnforceNotIdentityTransition(destinationState);
-                return InternalPermitIf(trigger, destinationState, guard, description);
+                return InternalPermitIf(trigger, destinationState, guard, guardDescription);
             }
 
             /// <summary>
@@ -73,15 +73,15 @@ namespace Stateless
             /// <param name="trigger">The accepted trigger.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
-            /// <param name="description">Guard description</param>
+            /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
             /// <remarks>
             /// Applies to the current state only. Will not re-execute superstate actions, or
             /// cause actions to execute transitioning between super- and sub-states.
             /// </remarks>
-            public StateConfiguration PermitReentryIf(TTrigger trigger, Func<bool> guard, string description = "")
+            public StateConfiguration PermitReentryIf(TTrigger trigger, Func<bool> guard, string guardDescription = "")
             {
-                return InternalPermitIf(trigger, _representation.UnderlyingState, guard, description);
+                return InternalPermitIf(trigger, _representation.UnderlyingState, guard, guardDescription);
             }
             /// <summary>
             /// Ignore the specified trigger when in the configured state.
@@ -98,14 +98,14 @@ namespace Stateless
             /// returns true..
             /// </summary>
             /// <param name="trigger">The trigger to ignore.</param>
-            /// <param name="description">Guard description</param>
+            /// <param name="guardDescription">Guard description</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be ignored.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration IgnoreIf(TTrigger trigger, Func<bool> guard, string description = "")
+            public StateConfiguration IgnoreIf(TTrigger trigger, Func<bool> guard, string guardDescription = "")
             {
                 Enforce.ArgumentNotNull(guard, "guard");
-                _representation.AddTriggerBehaviour(new IgnoredTriggerBehaviour(trigger, guard, description));
+                _representation.AddTriggerBehaviour(new IgnoredTriggerBehaviour(trigger, guard, guardDescription));
                 return this;
             }
 
@@ -114,12 +114,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="entryAction">Action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntry(Action entryAction, string description = "")
+            public StateConfiguration OnEntry(Action entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntry(t => entryAction(), description);
+                return OnEntry(t => entryAction(), entryActionDescription);
             }
 
             /// <summary>
@@ -127,12 +127,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntry(Action<Transition> entryAction, string description = "")
+            public StateConfiguration OnEntry(Action<Transition> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                _representation.AddEntryAction((t, args) => entryAction(t), description);
+                _representation.AddEntryAction((t, args) => entryAction(t), entryActionDescription);
                 return this;
             }
             /// <summary>
@@ -141,12 +141,12 @@ namespace Stateless
             /// </summary>
             /// <param name="entryAction">Action to execute.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom(TTrigger trigger, Action entryAction, string description = "")
+            public StateConfiguration OnEntryFrom(TTrigger trigger, Action entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom(trigger, t => entryAction(), description);
+                return OnEntryFrom(trigger, t => entryAction(), entryActionDescription);
             }
 
             /// <summary>
@@ -155,12 +155,12 @@ namespace Stateless
             /// </summary>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom(TTrigger trigger, Action<Transition> entryAction, string description = "")
+            public StateConfiguration OnEntryFrom(TTrigger trigger, Action<Transition> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                _representation.AddEntryAction(trigger, (t, args) => entryAction(t), description);
+                _representation.AddEntryAction(trigger, (t, args) => entryAction(t), entryActionDescription);
                 return this;
             }
 
@@ -171,12 +171,12 @@ namespace Stateless
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0> entryAction, string description = "")
+            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0>(trigger, (a0, t) => entryAction(a0), description);
+                return OnEntryFrom<TArg0>(trigger, (a0, t) => entryAction(a0), entryActionDescription);
             }
 
             /// <summary>
@@ -186,14 +186,14 @@ namespace Stateless
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0, Transition> entryAction, string description = "")
+            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0, Transition> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
-                    ParameterConversion.Unpack<TArg0>(args, 0), t), description);
+                    ParameterConversion.Unpack<TArg0>(args, 0), t), entryActionDescription);
                 return this;
             }
 
@@ -205,12 +205,12 @@ namespace Stateless
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1> entryAction, string description = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0, TArg1>(trigger, (a0, a1, t) => entryAction(a0, a1), description);
+                return OnEntryFrom<TArg0, TArg1>(trigger, (a0, a1, t) => entryAction(a0, a1), entryActionDescription);
             }
 
             /// <summary>
@@ -221,15 +221,15 @@ namespace Stateless
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1, Transition> entryAction, string description = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1, Transition> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
-                    ParameterConversion.Unpack<TArg1>(args, 1), t), description);
+                    ParameterConversion.Unpack<TArg1>(args, 1), t), entryActionDescription);
                 return this;
             }
 
@@ -242,12 +242,12 @@ namespace Stateless
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2> entryAction, string description = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0, TArg1, TArg2>(trigger, (a0, a1, a2, t) => entryAction(a0, a1, a2), description);
+                return OnEntryFrom<TArg0, TArg1, TArg2>(trigger, (a0, a1, a2, t) => entryAction(a0, a1, a2), entryActionDescription);
             }
 
             /// <summary>
@@ -259,16 +259,16 @@ namespace Stateless
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2, Transition> entryAction, string description = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2, Transition> entryAction, string entryActionDescription = "")
             {
                 Enforce.ArgumentNotNull(entryAction, "entryAction");
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
-                    ParameterConversion.Unpack<TArg2>(args, 2), t), description);
+                    ParameterConversion.Unpack<TArg2>(args, 2), t), entryActionDescription);
                 return this;
             }
 
@@ -277,12 +277,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="exitAction">Action to execute.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="onExitActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnExit(Action exitAction, string description = "")
+            public StateConfiguration OnExit(Action exitAction, string onExitActionDescription = "")
             {
                 Enforce.ArgumentNotNull(exitAction, "exitAction");
-                return OnExit(t => exitAction(), description);
+                return OnExit(t => exitAction(), onExitActionDescription);
             }
 
             /// <summary>
@@ -290,12 +290,12 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="exitAction">Action to execute, providing details of the transition.</param>
-            /// <param name="description">Action description.</param>
+            /// <param name="onExitActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnExit(Action<Transition> exitAction, string description = "")
+            public StateConfiguration OnExit(Action<Transition> exitAction, string onExitActionDescription = "")
             {
                 Enforce.ArgumentNotNull(exitAction, "exitAction");
-                _representation.AddExitAction(exitAction, description);
+                _representation.AddExitAction(exitAction, onExitActionDescription);
                 return this;
             }
 
@@ -387,12 +387,12 @@ namespace Stateless
             /// that the trigger will cause a transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
-            /// <param name="description">Guard description</param>
+            /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
-            public StateConfiguration PermitDynamicIf(TTrigger trigger, Func<TState> destinationStateSelector, Func<bool> guard, string description = "")
+            public StateConfiguration PermitDynamicIf(TTrigger trigger, Func<TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
-                return InternalPermitDynamicIf(trigger, args => destinationStateSelector(), guard, description);
+                return InternalPermitDynamicIf(trigger, args => destinationStateSelector(), guard, guardDescription);
             }
 
             /// <summary>
@@ -404,10 +404,10 @@ namespace Stateless
             /// that the trigger will cause a transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
-            /// <param name="description">Guard description</param>
+            /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<bool> guard, string description = "")
+            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
@@ -416,7 +416,7 @@ namespace Stateless
                     args => destinationStateSelector(
                         ParameterConversion.Unpack<TArg0>(args, 0)),
                     guard,
-                    description);
+                    guardDescription);
             }
 
             /// <summary>
@@ -428,11 +428,11 @@ namespace Stateless
             /// that the trigger will cause a transition to.</param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
-            /// <param name="description">Guard description</param>
+            /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<bool> guard, string description = "")
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
@@ -442,7 +442,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1)),
                     guard,
-                    description);
+                    guardDescription);
             }
 
             /// <summary>
@@ -455,11 +455,11 @@ namespace Stateless
             /// <returns>The reciever.</returns>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
-            /// <param name="description">Guard description</param>
+            /// <param name="guardDescription">Guard description</param>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
-            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<bool> guard, string description = "")
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
                 Enforce.ArgumentNotNull(trigger, "trigger");
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
@@ -470,7 +470,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg1>(args, 1),
                         ParameterConversion.Unpack<TArg2>(args, 2)),
                     guard,
-                    description);
+                    guardDescription);
             }
 
             void EnforceNotIdentityTransition(TState destination)
@@ -481,28 +481,28 @@ namespace Stateless
                 }
             }
 
-            StateConfiguration InternalPermit(TTrigger trigger, TState destinationState, string description)
+            StateConfiguration InternalPermit(TTrigger trigger, TState destinationState, string guardDescription)
             {
-                return InternalPermitIf(trigger, destinationState, () => true, description);
+                return InternalPermitIf(trigger, destinationState, () => true, guardDescription);
             }
 
-            StateConfiguration InternalPermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string description)
+            StateConfiguration InternalPermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string guardDescription)
             {
                 Enforce.ArgumentNotNull(guard, "guard");
-                _representation.AddTriggerBehaviour(new TransitioningTriggerBehaviour(trigger, destinationState, guard, description));
+                _representation.AddTriggerBehaviour(new TransitioningTriggerBehaviour(trigger, destinationState, guard, guardDescription));
                 return this;                
             }
 
-            StateConfiguration InternalPermitDynamic(TTrigger trigger, Func<object[], TState> destinationStateSelector, string description)
+            StateConfiguration InternalPermitDynamic(TTrigger trigger, Func<object[], TState> destinationStateSelector, string guardDescription)
             {
-                return InternalPermitDynamicIf(trigger, destinationStateSelector, NoGuard, description);
+                return InternalPermitDynamicIf(trigger, destinationStateSelector, NoGuard, guardDescription);
             }
 
-            StateConfiguration InternalPermitDynamicIf(TTrigger trigger, Func<object[], TState> destinationStateSelector, Func<bool> guard, string description)
+            StateConfiguration InternalPermitDynamicIf(TTrigger trigger, Func<object[], TState> destinationStateSelector, Func<bool> guard, string guardDescription)
             {
                 Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
                 Enforce.ArgumentNotNull(guard, "guard");
-                _representation.AddTriggerBehaviour(new DynamicTriggerBehaviour(trigger, destinationStateSelector, guard, description));
+                _representation.AddTriggerBehaviour(new DynamicTriggerBehaviour(trigger, destinationStateSelector, guard, guardDescription));
                 return this;
             }
         }

--- a/Stateless/StateConfiguration.cs
+++ b/Stateless/StateConfiguration.cs
@@ -18,8 +18,8 @@ namespace Stateless
 
             internal StateConfiguration(StateRepresentation representation, Func<TState, StateRepresentation> lookup)
             {
-                _representation = Enforce.ArgumentNotNull(representation, "representation");
-                _lookup = Enforce.ArgumentNotNull(lookup, "lookup");
+                _representation = Enforce.ArgumentNotNull(representation, nameof(representation));
+                _lookup = Enforce.ArgumentNotNull(lookup, nameof(lookup));
             }
 
             /// <summary>
@@ -45,10 +45,14 @@ namespace Stateless
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
-            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string guardDescription = "")
+            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string guardDescription = null)
             {
                 EnforceNotIdentityTransition(destinationState);
-                return InternalPermitIf(trigger, destinationState, guard, guardDescription);
+                return InternalPermitIf(
+                    trigger,
+                    destinationState,
+                    guard,
+                    guardDescription != null ? guardDescription : guard?.Method.Name);
             }
 
             /// <summary>
@@ -79,9 +83,13 @@ namespace Stateless
             /// Applies to the current state only. Will not re-execute superstate actions, or
             /// cause actions to execute transitioning between super- and sub-states.
             /// </remarks>
-            public StateConfiguration PermitReentryIf(TTrigger trigger, Func<bool> guard, string guardDescription = "")
+            public StateConfiguration PermitReentryIf(TTrigger trigger, Func<bool> guard, string guardDescription = null)
             {
-                return InternalPermitIf(trigger, _representation.UnderlyingState, guard, guardDescription);
+                return InternalPermitIf(
+                    trigger,
+                    _representation.UnderlyingState,
+                    guard,
+                    guardDescription != null ? guardDescription : guard?.Method.Name);
             }
             /// <summary>
             /// Ignore the specified trigger when in the configured state.
@@ -102,10 +110,14 @@ namespace Stateless
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be ignored.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration IgnoreIf(TTrigger trigger, Func<bool> guard, string guardDescription = "")
+            public StateConfiguration IgnoreIf(TTrigger trigger, Func<bool> guard, string guardDescription = null)
             {
-                Enforce.ArgumentNotNull(guard, "guard");
-                _representation.AddTriggerBehaviour(new IgnoredTriggerBehaviour(trigger, guard, guardDescription));
+                Enforce.ArgumentNotNull(guard, nameof(guard));
+                _representation.AddTriggerBehaviour(
+                    new IgnoredTriggerBehaviour(
+                        trigger,
+                        guard,
+                        guardDescription != null ? guardDescription : guard?.Method.Name));
                 return this;
             }
 
@@ -116,10 +128,12 @@ namespace Stateless
             /// <param name="entryAction">Action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntry(Action entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntry(Action entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntry(t => entryAction(), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntry(
+                    t => entryAction(),
+                    entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
             }
 
             /// <summary>
@@ -129,12 +143,15 @@ namespace Stateless
             /// <param name="entryAction">Action to execute, providing details of the transition.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntry(Action<Transition> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntry(Action<Transition> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                _representation.AddEntryAction((t, args) => entryAction(t), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                _representation.AddEntryAction(
+                    (t, args) => entryAction(t),
+                    entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
                 return this;
             }
+
             /// <summary>
             /// Specify an action that will execute when transitioning into
             /// the configured state.
@@ -143,10 +160,13 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom(TTrigger trigger, Action entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom(TTrigger trigger, Action entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom(trigger, t => entryAction(), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFrom(
+                    trigger,
+                    t => entryAction(),
+                    entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
             }
 
             /// <summary>
@@ -157,10 +177,13 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom(TTrigger trigger, Action<Transition> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom(TTrigger trigger, Action<Transition> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                _representation.AddEntryAction(trigger, (t, args) => entryAction(t), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                _representation.AddEntryAction(
+                    trigger,
+                    (t, args) => entryAction(t),
+                    entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
                 return this;
             }
 
@@ -173,10 +196,13 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0>(trigger, (a0, t) => entryAction(a0), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFrom<TArg0>(
+                    trigger,
+                    (a0, t) => entryAction(a0),
+                    entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
             }
 
             /// <summary>
@@ -188,12 +214,15 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0, Transition> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom<TArg0>(TriggerWithParameters<TArg0> trigger, Action<TArg0, Transition> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                Enforce.ArgumentNotNull(trigger, "trigger");
-                _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
-                    ParameterConversion.Unpack<TArg0>(args, 0), t), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
+                _representation.AddEntryAction(
+                    trigger.Trigger,
+                    (t, args) => entryAction(
+                        ParameterConversion.Unpack<TArg0>(args, 0), t),
+                        entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
                 return this;
             }
 
@@ -207,10 +236,12 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0, TArg1>(trigger, (a0, a1, t) => entryAction(a0, a1), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFrom<TArg0, TArg1>(
+                    trigger, 
+                    (a0, a1, t) => entryAction(a0, a1), entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
             }
 
             /// <summary>
@@ -223,13 +254,13 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1, Transition> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1, Transition> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                Enforce.ArgumentNotNull(trigger, "trigger");
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
-                    ParameterConversion.Unpack<TArg1>(args, 1), t), entryActionDescription);
+                    ParameterConversion.Unpack<TArg1>(args, 1), t), entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
                 return this;
             }
 
@@ -244,10 +275,12 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                return OnEntryFrom<TArg0, TArg1, TArg2>(trigger, (a0, a1, a2, t) => entryAction(a0, a1, a2), entryActionDescription);
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFrom<TArg0, TArg1, TArg2>(
+                    trigger, 
+                    (a0, a1, a2, t) => entryAction(a0, a1, a2), entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
             }
 
             /// <summary>
@@ -261,14 +294,14 @@ namespace Stateless
             /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
             /// <param name="entryActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2, Transition> entryAction, string entryActionDescription = "")
+            public StateConfiguration OnEntryFrom<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2, Transition> entryAction, string entryActionDescription = null)
             {
-                Enforce.ArgumentNotNull(entryAction, "entryAction");
-                Enforce.ArgumentNotNull(trigger, "trigger");
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
                 _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
-                    ParameterConversion.Unpack<TArg2>(args, 2), t), entryActionDescription);
+                    ParameterConversion.Unpack<TArg2>(args, 2), t), entryActionDescription != null ? entryActionDescription : entryAction.Method.Name);
                 return this;
             }
 
@@ -277,12 +310,14 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="exitAction">Action to execute.</param>
-            /// <param name="onExitActionDescription">Action description.</param>
+            /// <param name="exitActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnExit(Action exitAction, string onExitActionDescription = "")
+            public StateConfiguration OnExit(Action exitAction, string exitActionDescription = null)
             {
-                Enforce.ArgumentNotNull(exitAction, "exitAction");
-                return OnExit(t => exitAction(), onExitActionDescription);
+                Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
+                return OnExit(
+                    t => exitAction(),
+                    exitActionDescription != null ? exitActionDescription : exitAction.Method.Name);
             }
 
             /// <summary>
@@ -290,12 +325,14 @@ namespace Stateless
             /// the configured state.
             /// </summary>
             /// <param name="exitAction">Action to execute, providing details of the transition.</param>
-            /// <param name="onExitActionDescription">Action description.</param>
+            /// <param name="exitActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnExit(Action<Transition> exitAction, string onExitActionDescription = "")
+            public StateConfiguration OnExit(Action<Transition> exitAction, string exitActionDescription = null)
             {
-                Enforce.ArgumentNotNull(exitAction, "exitAction");
-                _representation.AddExitAction(exitAction, onExitActionDescription);
+                Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
+                _representation.AddExitAction(
+                    exitAction,
+                    exitActionDescription != null ? exitActionDescription : exitAction.Method.Name);
                 return this;
             }
 
@@ -391,7 +428,7 @@ namespace Stateless
             /// <returns>The reciever.</returns>
             public StateConfiguration PermitDynamicIf(TTrigger trigger, Func<TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
-                Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
+                Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
                 return InternalPermitDynamicIf(trigger, args => destinationStateSelector(), guard, guardDescription);
             }
 
@@ -409,8 +446,8 @@ namespace Stateless
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
-                Enforce.ArgumentNotNull(trigger, "trigger");
-                Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
+                Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
                 return InternalPermitDynamicIf(
                     trigger.Trigger,
                     args => destinationStateSelector(
@@ -434,8 +471,8 @@ namespace Stateless
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
             public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
-                Enforce.ArgumentNotNull(trigger, "trigger");
-                Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
+                Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
                 return InternalPermitDynamicIf(
                     trigger.Trigger,
                     args => destinationStateSelector(
@@ -461,8 +498,8 @@ namespace Stateless
             /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
             public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<bool> guard, string guardDescription = "")
             {
-                Enforce.ArgumentNotNull(trigger, "trigger");
-                Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
+                Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
                 return InternalPermitDynamicIf(
                     trigger.Trigger,
                     args => destinationStateSelector(
@@ -488,9 +525,9 @@ namespace Stateless
 
             StateConfiguration InternalPermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string guardDescription)
             {
-                Enforce.ArgumentNotNull(guard, "guard");
+                Enforce.ArgumentNotNull(guard, nameof(guard));
                 _representation.AddTriggerBehaviour(new TransitioningTriggerBehaviour(trigger, destinationState, guard, guardDescription));
-                return this;                
+                return this;
             }
 
             StateConfiguration InternalPermitDynamic(TTrigger trigger, Func<object[], TState> destinationStateSelector, string guardDescription)
@@ -500,8 +537,8 @@ namespace Stateless
 
             StateConfiguration InternalPermitDynamicIf(TTrigger trigger, Func<object[], TState> destinationStateSelector, Func<bool> guard, string guardDescription)
             {
-                Enforce.ArgumentNotNull(destinationStateSelector, "destinationStateSelector");
-                Enforce.ArgumentNotNull(guard, "guard");
+                Enforce.ArgumentNotNull(destinationStateSelector, nameof(destinationStateSelector));
+                Enforce.ArgumentNotNull(guard, nameof(guard));
                 _representation.AddTriggerBehaviour(new DynamicTriggerBehaviour(trigger, destinationStateSelector, guard, guardDescription));
                 return this;
             }

--- a/Stateless/StateRepresentation.cs
+++ b/Stateless/StateRepresentation.cs
@@ -62,37 +62,37 @@ namespace Stateless
                 return handler != null;
             }
 
-            public void AddEntryAction(TTrigger trigger, Action<Transition, object[]> action, string description = "")
+            public void AddEntryAction(TTrigger trigger, Action<Transition, object[]> action, string entryActionDescription)
             {
-                Enforce.ArgumentNotNull(action, "action");
+                Enforce.ArgumentNotNull(action, nameof(action));
                 _entryActions.Add(
                     new EntryActionBehavior((t, args) =>
                     {
                         if (t.Trigger.Equals(trigger))
                             action(t, args);
                     },
-                    string.IsNullOrEmpty(description) ? action.Method.Name : description));
+                    Enforce.ArgumentNotNull(entryActionDescription, nameof(entryActionDescription))));
             }
 
-            public void AddEntryAction(Action<Transition, object[]> action, string description = "")
+            public void AddEntryAction(Action<Transition, object[]> action, string entryActionDescription)
             {
                 _entryActions.Add(
                     new EntryActionBehavior(
-                        Enforce.ArgumentNotNull(action, "action"),
-                        string.IsNullOrEmpty(description) ? action.Method.Name : description));
+                        Enforce.ArgumentNotNull(action, nameof(action)),
+                        Enforce.ArgumentNotNull(entryActionDescription, nameof(entryActionDescription))));
             }
 
-            public void AddExitAction(Action<Transition> action, string description = "")
+            public void AddExitAction(Action<Transition> action, string exitActionDescription)
             {
                 _exitActions.Add(
                     new ExitActionBehavior(
-                        Enforce.ArgumentNotNull(action, "action"),
-                       string.IsNullOrEmpty(description) ? action.Method.Name : description));
+                        Enforce.ArgumentNotNull(action, nameof(action)),
+                        Enforce.ArgumentNotNull(exitActionDescription, nameof(exitActionDescription))));
             }
 
             public void Enter(Transition transition, params object[] entryArgs)
             {
-                Enforce.ArgumentNotNull(transition, "transition");
+                Enforce.ArgumentNotNull(transition, nameof(transition));
 
                 if (transition.IsReentry)
                 {
@@ -109,7 +109,7 @@ namespace Stateless
 
             public void Exit(Transition transition)
             {
-                Enforce.ArgumentNotNull(transition, "transition");
+                Enforce.ArgumentNotNull(transition, nameof(transition));
 
                 if (transition.IsReentry)
                 {
@@ -125,15 +125,15 @@ namespace Stateless
 
             void ExecuteEntryActions(Transition transition, object[] entryArgs)
             {
-                Enforce.ArgumentNotNull(transition, "transition");
-                Enforce.ArgumentNotNull(entryArgs, "entryArgs");
+                Enforce.ArgumentNotNull(transition, nameof(transition));
+                Enforce.ArgumentNotNull(entryArgs, nameof(entryArgs));
                 foreach (var action in _entryActions)
                     action.Action(transition, entryArgs);
             }
 
             void ExecuteExitActions(Transition transition)
             {
-                Enforce.ArgumentNotNull(transition, "transition");
+                Enforce.ArgumentNotNull(transition, nameof(transition));
                 foreach (var action in _exitActions)
                     action.Action(transition);
             }
@@ -171,7 +171,7 @@ namespace Stateless
 
             public void AddSubstate(StateRepresentation substate)
             {
-                Enforce.ArgumentNotNull(substate, "substate");
+                Enforce.ArgumentNotNull(substate, nameof(substate));
                 _substates.Add(substate);
             }
 

--- a/Stateless/Stateless.csproj
+++ b/Stateless/Stateless.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Enforce.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ExitActionBehaviour.cs" />
     <Compile Include="IgnoredTriggerBehaviour.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -118,6 +119,7 @@
     <Compile Include="TransitioningTriggerBehaviour.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="EntryActionBehaviour.cs" />
     <Compile Include="TriggerBehaviour.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Stateless/TransitioningTriggerBehaviour.cs
+++ b/Stateless/TransitioningTriggerBehaviour.cs
@@ -14,7 +14,12 @@ namespace Stateless
             internal TState Destination { get { return _destination; } }
 
             public TransitioningTriggerBehaviour(TTrigger trigger, TState destination, Func<bool> guard)
-                : base(trigger, guard)
+                : this(trigger, destination, guard, string.Empty)
+            {
+            }
+
+            public TransitioningTriggerBehaviour(TTrigger trigger, TState destination, Func<bool> guard, string description)
+                : base(trigger, guard, description)
             {
                 _destination = destination;
             }

--- a/Stateless/TriggerBehaviour.cs
+++ b/Stateless/TriggerBehaviour.cs
@@ -11,15 +11,18 @@ namespace Stateless
         {
             readonly TTrigger _trigger;
             readonly Func<bool> _guard;
+            readonly string _description;
 
-            protected TriggerBehaviour(TTrigger trigger, Func<bool> guard)
+            protected TriggerBehaviour(TTrigger trigger, Func<bool> guard, string description)
             {
                 _trigger = trigger;
                 _guard = guard;
+                _description = description;
             }
 
             public TTrigger Trigger { get { return _trigger; } }
             internal Func<bool> Guard { get { return _guard; } }
+            internal string Description{ get { return string.IsNullOrEmpty(_description) ? _guard.Method.Name : _description ; } }
 
             public bool IsGuardConditionMet
             {

--- a/Stateless/TriggerBehaviour.cs
+++ b/Stateless/TriggerBehaviour.cs
@@ -17,12 +17,12 @@ namespace Stateless
             {
                 _trigger = trigger;
                 _guard = guard;
-                _guardDescription = guardDescription;
+                _guardDescription = Enforce.ArgumentNotNull(guardDescription, nameof(guardDescription));
             }
 
             public TTrigger Trigger { get { return _trigger; } }
             internal Func<bool> Guard { get { return _guard; } }
-            internal string GuardDescription{ get { return string.IsNullOrEmpty(_guardDescription) ? _guard.Method.Name : _guardDescription ; } }
+            internal string GuardDescription{ get { return _guardDescription ; } }
 
             public bool IsGuardConditionMet
             {

--- a/Stateless/TriggerBehaviour.cs
+++ b/Stateless/TriggerBehaviour.cs
@@ -11,18 +11,18 @@ namespace Stateless
         {
             readonly TTrigger _trigger;
             readonly Func<bool> _guard;
-            readonly string _description;
+            readonly string _guardDescription;
 
-            protected TriggerBehaviour(TTrigger trigger, Func<bool> guard, string description)
+            protected TriggerBehaviour(TTrigger trigger, Func<bool> guard, string guardDescription)
             {
                 _trigger = trigger;
                 _guard = guard;
-                _description = description;
+                _guardDescription = guardDescription;
             }
 
             public TTrigger Trigger { get { return _trigger; } }
             internal Func<bool> Guard { get { return _guard; } }
-            internal string Description{ get { return string.IsNullOrEmpty(_description) ? _guard.Method.Name : _description ; } }
+            internal string GuardDescription{ get { return string.IsNullOrEmpty(_guardDescription) ? _guard.Method.Name : _guardDescription ; } }
 
             public bool IsGuardConditionMet
             {


### PR DESCRIPTION
Hi, I've been using stateless for several months now and one of my clients was missing meaningful descriptions for *Trigger Guards*, *OnEntry* and *OnExit* actions within the *DotGraph* feature.

For instance now it's possible to write the following code (which removes the compiler generated method names such as *<test>b__5_0* from the resulting string):

    machine.Configure(State.A)
        .OnEntry(() => { }, "Just entered A")
        .PermitIf(Trigger.X, State.B, () => true, "description");

And get the following *DotGraph* string:

    digraph {
     A -> B [label="X [description]"];
     node [shape=box];
     A -> "Just entered A" [label="On Entry" style=dotted];
    }

Hope you like it as much as our client  does and thanks for sharing this great code!!!
Carlos

